### PR TITLE
simplify fetch method

### DIFF
--- a/lib/simple_parameter_store.rb
+++ b/lib/simple_parameter_store.rb
@@ -24,10 +24,10 @@ class SimpleParameterStore
   attr_reader :client, :prefix, :decrypt, :expires_after, :expires_at
 
   def refresh
-    fetch.each do |parameter|
-      key, = @mappings.rassoc(parameter.name)
+    fetch.each_pair do |name, value|
+      key, = @mappings.rassoc(name)
       caster = @casters.fetch(key)
-      value = caster.call(parameter.value)
+      value = caster.call(value)
       @cache[key] = value
     end
 
@@ -53,7 +53,7 @@ class SimpleParameterStore
     result = client.get_parameters(names: @mappings.values, with_decryption: decrypt)
     raise SSMKeyError, "Missing keys: `#{result.invalid_parameters}`" if result.invalid_parameters.any?
 
-    result.parameters
+    result.parameters.map { |parameter| [parameter.name, parameter.value] }.to_h
   end
 
   def prepare(names)

--- a/lib/simple_parameter_store/mock.rb
+++ b/lib/simple_parameter_store/mock.rb
@@ -4,14 +4,6 @@ class SimpleParameterStore
   module Mock
     class MockError < StandardError; end
 
-    class Parameter
-      attr_reader :name, :value
-      def initialize(name, value)
-        @name = name
-        @value = value
-      end
-    end
-
     def self.prepended(base)
       base.extend ClassMethods
     end
@@ -45,7 +37,7 @@ class SimpleParameterStore
 
       def mock=(names:, client: nil, prefix: nil, decrypt: true, expires_after: nil)
         @mock = {
-          cache: names.map { |(key, value)| Parameter.new("#{prefix}#{key}", value) },
+          cache: names.transform_keys { |key| "#{prefix}#{key}" },
           prefix: prefix,
           decrypt: decrypt,
           expires_after: expires_after,


### PR DESCRIPTION
In this way the parameter store result object details don't leak any more from `fetch` into `refresh`.